### PR TITLE
Isolated numpy/cython to fix requirement issues with pip.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,61 +15,72 @@ import sys
 if sys.version_info[:2] < (2, 5):
     raise Exception('This version of sparsesvd needs Python 2.5 or later.')
 
-import Cython
-# may need to work around setuptools bug by providing a fake Pyrex
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "fake_pyrex"))
-
-
-import ez_setup
-ez_setup.use_setuptools()
-from setuptools import setup, Extension
-
-from Cython.Distutils import build_ext
-
-from numpy.distutils.misc_util import get_numpy_include_dirs
-
 sourcefiles = ['sparsesvd.pyx', 'SVDLIBC/las2.c', 'SVDLIBC/svdutil.c', 'SVDLIBC/svdlib.c']
 
-setup(
-    name = 'sparsesvd',
-    version = '0.1.9',
-    description = 'Python module that wraps SVDLIBC, a library for sparse Singular Value Decomposition.',
-    long_description = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read(),
-    license = 'BSD',
-    keywords = 'Singular Value Decomposition, SVD, sparse SVD',
-    # there is a bug in python2.5, preventing distutils from using any non-ascii characters :( http://bugs.python.org/issue2562
-    author = 'Radim Rehurek', # u'Radim Řehůřek', # <- should really be this...
-    author_email = 'radimrehurek@seznam.cz',
-    url = 'http://pypi.python.org/pypi/sparsesvd',
-    download_url = 'http://pypi.python.org/pypi/sparsesvd',
-    zip_safe = False,
-    platforms = 'any',
-    include_package_data = True,
-    entry_points = {},
-    cmdclass = {'build_ext': build_ext},
+def setup_package():
+    META_DATA = dict(
+        name = 'sparsesvd',
+        version = '0.1.9',
+        description = 'Python module that wraps SVDLIBC, a library for sparse Singular Value Decomposition.',
+        long_description = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read(),
+        license = 'BSD',
+        keywords = 'Singular Value Decomposition, SVD, sparse SVD',
+        # there is a bug in python2.5, preventing distutils from using any non-ascii characters :( http://bugs.python.org/issue2562
+        author = 'Radim Rehurek', # u'Radim Řehůřek', # <- should really be this...
+        author_email = 'radimrehurek@seznam.cz',
+        url = 'http://pypi.python.org/pypi/sparsesvd',
+        download_url = 'http://pypi.python.org/pypi/sparsesvd',
+        zip_safe = False,
+        platforms = 'any',
+        include_package_data = True,
+        entry_points = {},
 
-    classifiers = [ # from http://pypi.python.org/pypi?%3Aaction=list_classifiers
-        'Development Status :: 4 - Beta',
-        'Environment :: Console',
-        'Intended Audience :: Science/Research',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2.5',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.2',
-        'Topic :: Scientific/Engineering :: Mathematics',
-        'Topic :: Scientific/Engineering :: Artificial Intelligence',
-        'Topic :: Scientific/Engineering :: Information Analysis',
-        'Topic :: Text Processing :: Linguistic',
-        'License :: OSI Approved :: BSD License',
-    ],
+        classifiers = [ # from http://pypi.python.org/pypi?%3Aaction=list_classifiers
+            'Development Status :: 4 - Beta',
+            'Environment :: Console',
+            'Intended Audience :: Science/Research',
+            'Operating System :: OS Independent',
+            'Programming Language :: Python :: 2.5',
+            'Programming Language :: Python :: 2.6',
+            'Programming Language :: Python :: 2.7',
+            'Programming Language :: Python :: 3.2',
+            'Topic :: Scientific/Engineering :: Mathematics',
+            'Topic :: Scientific/Engineering :: Artificial Intelligence',
+            'Topic :: Scientific/Engineering :: Information Analysis',
+            'Topic :: Text Processing :: Linguistic',
+            'License :: OSI Approved :: BSD License',
+        ],
 
-    test_suite = "test",
+        test_suite = "test",
 
-    install_requires = [
-        'scipy >= 0.6.0',
-        'cython',
-    ],
+        install_requires = [
+            'scipy >= 0.6.0',
+            'cython',
+        ],
+    )
 
-    ext_modules = [Extension("sparsesvd", sourcefiles, include_dirs=get_numpy_include_dirs())],
-)
+    if '--help' in sys.argv[1:] or \
+      sys.argv[1] in ('--help-commands', 'egg_info', '--version'):
+        pass
+    else:
+        import Cython  # NOQA
+        # may need to work around setuptools bug by providing a fake Pyrex
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "fake_pyrex"))
+
+        import ez_setup
+        ez_setup.use_setuptools()
+        from setuptools import Extension
+
+        from Cython.Distutils import build_ext
+        from numpy.distutils.misc_util import get_numpy_include_dirs
+
+        META_DATA['cmdclass'] = {'build_ext': build_ext}
+        META_DATA['ext_modules'] = [Extension("sparsesvd", sourcefiles, include_dirs=get_numpy_include_dirs())]
+
+    from setuptools import setup
+
+    setup(**META_DATA)
+
+
+if __name__ == '__main__':
+    setup_package()


### PR DESCRIPTION
Right now, setup.py will not even run without numpy/cython already being installed.  Scipy had a similar issue (see https://github.com/scipy/scipy/pull/453) which has now been resolved.  This change isolates the numpy/cython dependencies in a smilar fashion such that running `pip install numpy scipy cython sparsesvd` works (assuming you are using a recent version of scipy with the aforementioned patch)
